### PR TITLE
Add blackduck license scan integration

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,0 +1,34 @@
+name: Blackduck - PR Analysis
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  black-duck:
+    runs-on: ubuntu-latest
+    env:
+      # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
+      BLACKDUCK_URL: ${{ secrets.BLACKDUCK_URL }}
+    steps:
+      - name: Checkout
+        if: ${{ env.BLACKDUCK_URL != '' }}
+        uses: actions/checkout@v2
+      - name: Set up Java 11
+        if: ${{ env.BLACKDUCK_URL != '' }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Run Synopsys Detect
+        if: ${{ env.BLACKDUCK_URL != '' }}
+        uses: synopsys-sig/detect-action@v0.3.0
+        with:
+          scan-mode: 'INTELLIGENT'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          detect-version: 7.14.0
+          detect-trust-cert: false
+          blackduck-url: ${{ secrets.BLACKDUCK_URL }}
+          blackduck-api-token: ${{ secrets.BLACKDUCK_API_TOKEN }}

--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,2 @@
+detect.project.name: resin-release-tool
+detect.project.version.name: main


### PR DESCRIPTION
Uses synopsys-sig/detect-action, and is based on the integration used elsewhere internally.

Not really tested yet, since I'm not entirely sure how to test Github Actions changes. I tried testing with [act][1], but ran into to-me nonsensical problems (permission error trying to clone a public repo, or string interpolations not matching the Github Actions docs).

Apart from the conditionals (which should match the [docs for those][2], jumping through hoops to test for the presence of a secret), it's basically what we're using in other internal projects though, and fairly straightforward use of the [synopsys-sig/detect-action orb][3].

[1]: https://github.com/nektos/act 
[2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
[3]: https://github.com/synopsys-sig/detect-action