### PR TITLE
chore(.github/workflow): use Python 3.10 in publish-to-pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10.0
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
-        python-version: 3.10.0
+        python-version: "3.10"
 
     - name: Gets the tag version
       id: context

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change log
 
+## v0.3.2 (2023-03-09)
+* fix github release workflow
+
 ## v0.3.1 (2023-03-07)
+* bump minimum Python version to 3.9
 * update dependencies
 
 ## v0.3.0 (2022-06-09)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "resin-release-tool"
-version = "v0.3.1"
+version = "v0.3.2"
 readme = "README.md"
 description = "Release tool to have canary in resin.io"
 homepage = "https://github.com/mobilityhouse/resin-release-tool"


### PR DESCRIPTION
Uses "3.10" (latest 3.10.x) instead of 3.10.0 in this workflow as well.

The same problem was addressed in the pull-request workflow already (it was 3.10.0 before due to YAML numeric/string rules I assume).