### PR TITLE
GRID-3738: Implement support for multiple release groups per device

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ resin-release-tool --app $APP_ID unpin canary
 
 ### Staggered release with multiple groups
 
-Mark relevant devices with device tags with name "release_group" and value "release_group_1/2/3" on balenaCloud.
+Mark relevant devices with device tags with name `release_group` and value "release_group_1/2/3" on balenaCloud. If you want multiple release groups on one unit, you can do that by putting a comma between them in the `release_group` tag (for example: `canary,release_group_1`).
 
 **To deploy a commit to all devices in a staggered way:**
 

--- a/resin_release_tool/releaser.py
+++ b/resin_release_tool/releaser.py
@@ -76,7 +76,8 @@ Check also 'pine_endpoint' there\n"
         release_group_devices = [
             tag["device"]["__id"]
             for tag in tags
-            if tag["tag_key"] == "release_group" and tag["value"] == release_group
+            if tag["tag_key"] == "release_group"
+            and release_group in tag["value"].split(",")
         ]
         return release_group_devices
 
@@ -97,7 +98,8 @@ Check also 'pine_endpoint' there\n"
         for tag in tags:
             if tag["tag_key"] != "release_group":
                 continue
-            release_groups[tag["value"]].append(tag["device"]["__id"])
+            for release_group in tag["value"].split(","):
+                release_groups[release_group].append(tag["device"]["__id"])
 
         return dict(release_groups)
 


### PR DESCRIPTION
We want to have units in both regular unitsets that map to physical sites and a CANARY group, so we can choose to deploy to canary, and also separately to the unitset.